### PR TITLE
Use portable XBRL validation and add unit test

### DIFF
--- a/knowledge_base/src/ingestion/sec_sql_extractor.py
+++ b/knowledge_base/src/ingestion/sec_sql_extractor.py
@@ -122,8 +122,8 @@ class SECDataExtractor(BaseFinancialExtractor):
         try:
             tree = ET.parse(file_path)
             root = tree.getroot()
-            # Check for XBRL namespaces
-            return any('xbrl' in ns for ns in root.nsmap.values() if root.nsmap and ns)
+            # Check for XBRL elements in a portable way
+            return any('xbrl' in elem.tag.lower() for elem in root.iter())
         except:
             return False
 

--- a/knowledge_base/tests/test_sec_sql_extractor.py
+++ b/knowledge_base/tests/test_sec_sql_extractor.py
@@ -1,0 +1,14 @@
+import pytest
+from pathlib import Path
+from knowledge_base.src.ingestion.sec_sql_extractor import SECDataExtractor
+
+
+class TestSECDataExtractor:
+    def test_validate_xbrl_file(self, tmp_path):
+        extractor = SECDataExtractor()
+        xbrl_content = """<?xml version='1.0' encoding='UTF-8'?>
+<xbrl xmlns='http://www.xbrl.org/2003/instance'></xbrl>
+"""
+        xbrl_file = tmp_path / "sample.xbrl"
+        xbrl_file.write_text(xbrl_content)
+        assert extractor._validate_xbrl_file(xbrl_file) is True


### PR DESCRIPTION
## Summary
- Ensure `_validate_xbrl_file` doesn't rely on `nsmap` by checking element tags for `xbrl`
- Add unit test verifying `_validate_xbrl_file` accepts a minimal XBRL snippet

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pillow_heif')*
- `pytest knowledge_base/tests/test_sec_sql_extractor.py`

------
https://chatgpt.com/codex/tasks/task_e_68acb2ad6cbc8322adcc39858bef5353