### PR TITLE
docs: fix typo in SEC SQL extractor comment

### DIFF
--- a/knowledge_base/src/ingestion/sec_sql_extractor.py
+++ b/knowledge_base/src/ingestion/sec_sql_extractor.py
@@ -12,7 +12,7 @@ Why this approach:
 Maximum Fidelity: XBRL provides exact, audited financial data
 Fallback Robustness: PDF parsing when XBRL unavailable
 Vector DB Synergy: Extract precise numbers for SQL, contextual narratives for vectors
-Regulatory Compliance: XBRL is the official structured forma
+Regulatory Compliance: XBRL is the official structured format.
 
 
 This extraction code prioritizes fidelity and accuracy through:


### PR DESCRIPTION
## Summary
- fix `format` typo in SEC financial data extractor comment

## Testing
- `flake8 knowledge_base/src/ingestion/sec_sql_extractor.py` *(fails: multiple existing style violations)*


------
https://chatgpt.com/codex/tasks/task_e_68acb2abe1e88322a3ab335d2511cbac